### PR TITLE
updated testbed documentation for changes in the docker image

### DIFF
--- a/apache/flink/exposedui/README.md
+++ b/apache/flink/exposedui/README.md
@@ -2,4 +2,9 @@
 ```bash
 docker compose up --no-build
 ```
+
+Note: depending on the version of the docker image, the port can change.
+
+tag "simple" uses port 8081, while tag 1.20.1 uses port 8083.
+
 Open http://127.0.0.1:8083/#/submit


### PR DESCRIPTION
Had trouble reproducing the detector with the testbed, updated it to use a different port depending on version.